### PR TITLE
Increase timeout to 10 seconds

### DIFF
--- a/custom_components/eforsyning/pyeforsyning/eforsyning.py
+++ b/custom_components/eforsyning/pyeforsyning/eforsyning.py
@@ -101,7 +101,7 @@ class Eforsyning:
 
         result = requests.post(installationsURL,
                                 data = json.dumps(data),
-                                timeout = 5,
+                                timeout = 10,
                                 headers=headers
                               )
 
@@ -145,7 +145,7 @@ class Eforsyning:
         headers = self._create_headers()
 
         result = requests.post(getaktuelaarsmaerkeURL,
-                                timeout = 5,
+                                timeout = 10,
                                 headers=headers
                               )
 
@@ -265,7 +265,7 @@ class Eforsyning:
         try:
             result = requests.post(self._api_server + post_meter_data_url,
                                     data = json.dumps(data),
-                                    timeout = 5,
+                                    timeout = 10,
                                     headers=headers
                                 )
         except requests.exceptions.Timeout:
@@ -297,7 +297,7 @@ class Eforsyning:
         try:
             result = requests.post(self._api_server + post_billing_data_url,
                                     data = json.dumps(data),
-                                    timeout = 5,
+                                    timeout = 10,
                                     headers=headers
                                 )
         except requests.exceptions.RequestException:


### PR DESCRIPTION
![image](https://github.com/kpoppel/homeassistant-eforsyning/assets/26626066/c09e8705-eaad-42fa-b6d4-a48967c2406d)

This endpoint fails all the time due to timeout error: /api/FindInstallationer?id=

Increasing the timeout to 10 seconds solved the issues.